### PR TITLE
Added missing UIKit import statement so that Countly will successfully compile when UIKit.h is not imported globally.

### DIFF
--- a/Countly.m
+++ b/Countly.m
@@ -17,6 +17,7 @@
 
 #import "Countly.h"
 #import "Countly_OpenUDID.h"
+#import <UIKit/UIKit.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #import <CoreTelephony/CTCarrier.h>
 


### PR DESCRIPTION
...endency.

The Countly class uses methods from the UIKit framework however it doesn't import that framework. This wont be a problem for most apps because the default project template for Xcode imports the UIKit framework in the apps Prefix.pch. However when an application doesn't use the provided Prefix.pch the Countly class will fail to compile.
