### PR TITLE
Fix memory leak

### DIFF
--- a/Countly_OpenUDID.m
+++ b/Countly_OpenUDID.m
@@ -136,6 +136,7 @@ static int const kOpenUDIDRedundancySlots = 100;
         const char *cStr = CFStringGetCStringPtr(cfstring,CFStringGetFastestEncoding(cfstring));
         unsigned char result[16];
         CC_MD5( cStr, strlen(cStr), result );
+        CFRelease(cfstring);
         CFRelease(uuid);
 
         _openUDID = [NSString stringWithFormat:


### PR DESCRIPTION
I think cfstring should be also released when it's not used anymore. Static analyzer says the same thing.
