### PR TITLE
Use own bundle for own resources

### DIFF
--- a/CountlyDB.m
+++ b/CountlyDB.m
@@ -206,7 +206,7 @@
 
     static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
-        NSURL *modelURL = [[NSBundle mainBundle] URLForResource:@"Countly" withExtension:@"momd"];
+        NSURL *modelURL = [[NSBundle bundleForClass:[CountlyDB class]] URLForResource:@"Countly" withExtension:@"momd"];
         s_managedObjectModel = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
     });
 


### PR DESCRIPTION
When using County cocoa pod as a framework, `mainBundle` refers to the app's bundle, and County is a separate one. Using `bundleForClass:` fixes this, like suggested here: http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/