### PR TITLE
- fix issue where OSX app won't send events until 10 events are queue…

### DIFF
--- a/Countly.m
+++ b/Countly.m
@@ -909,6 +909,20 @@ NSString* const kCLYUserCustom = @"custom";
 												 selector:@selector(willTerminateCallBack:)
 													 name:UIApplicationWillTerminateNotification
 												   object:nil];
+#elif TARGET_OS_MAC
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(didEnterBackgroundCallBack:)
+                                                     name:NSApplicationDidResignActiveNotification
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(willEnterForegroundCallBack:)
+                                                     name:NSApplicationWillBecomeActiveNotification
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(willTerminateCallBack:)
+                                                     name:NSApplicationWillTerminateNotification
+                                                   object:nil];
+
 #endif
 	}
 	return self;


### PR DESCRIPTION
…d up. The problem was - there was no detection of OSX application being exited and events flushed which is how iOS version works. There's also no way to manually send the events. Now, events are flushed when app goes to the background/foreground/exits (the foreground/background events might not be necessary given this is a desktop)