### PR TITLE
Fix event database collision for Mac

### DIFF
--- a/CountlyDB.m
+++ b/CountlyDB.m
@@ -192,6 +192,10 @@ To use Countly iOS SDK in WatchKit apps:
     NSURL *url = [[fm URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask] lastObject];
     NSError *error = nil;
     
+#if TARGET_OS_MAC
+    url = [url URLByAppendingPathComponent:[[NSBundle mainBundle] bundleIdentifier]];
+#endif
+
     if (![fm fileExistsAtPath:[url absoluteString]])
     {
         [fm createDirectoryAtURL:url withIntermediateDirectories:YES attributes:nil error:&error];


### PR DESCRIPTION
For multiple apps with countly enabled running on the same Mac, instead of storing all their events into `~/Library/Application Support/County.sqlite`, this pull request splits them into `~/Library/Application Support/<bundle id>/County.sqlite`. So that events from each of them won't collide with each other. 