### PR TITLE
Add SIGTRAP to list of signals that are caught by crash reporting

### DIFF
--- a/Countly.m
+++ b/Countly.m
@@ -1364,6 +1364,7 @@ NSString* const kCLYUserCustom = @"custom";
 	signal(SIGFPE, CountlySignalHandler);
 	signal(SIGBUS, CountlySignalHandler);
 	signal(SIGPIPE, CountlySignalHandler);
+	signal(SIGTRAP, CountlySignalHandler);
 }
 
 - (void)startCrashReportingWithSegments:(NSDictionary *)segments
@@ -1489,6 +1490,7 @@ void CountlyExceptionHandler(NSException *exception, bool nonfatal)
 	signal(SIGFPE, SIG_DFL);
 	signal(SIGBUS, SIG_DFL);
 	signal(SIGPIPE, SIG_DFL);
+	signal(SIGTRAP, SIG_DFL);
 }
 
 void CountlySignalHandler(int signalCode)


### PR DESCRIPTION
Countly was not reporting nil unwrapping and other invalid access errors in Swift apps.
With Swift code, nil/null pointer access results in a EXC_BREAKPOINT Mach exception on ARM (not an objective-c exception or SIGSEGV), and this maps to SIGTRAP.