### PR TITLE
fixed bug of mutating request array when archiving data

### DIFF
--- a/CountlyPersistency.m
+++ b/CountlyPersistency.m
@@ -195,7 +195,7 @@ NSString* const kCountlyStarRatingStatusKey = @"kCountlyStarRatingStatusKey";
 - (void)saveToFileSync
 {
     NSDictionary* saveDict = @{
-                                kCountlyQueuedRequestsPersistencyKey:self.queuedRequests
+                                kCountlyQueuedRequestsPersistencyKey:self.queuedRequests.copy
                               };
     NSData* saveData;
 

--- a/CountlyUserDetails.m
+++ b/CountlyUserDetails.m
@@ -71,6 +71,9 @@ NSString* const kCountlyLocalPicturePath = @"kCountlyLocalPicturePath";
 {
 #if TARGET_OS_IOS
     NSString* unescaped = [requestString stringByRemovingPercentEncoding];
+    if (!unescaped) {
+        return nil;
+    }
     NSRange rLocalPicturePath = [unescaped rangeOfString:kCountlyLocalPicturePath];
     if (rLocalPicturePath.location == NSNotFound)
         return nil;


### PR DESCRIPTION
fixed bug when saving requests to file, the error info below:
Fatal Exception: NSGenericException
0  CoreFoundation                 0x1897741c0 __exceptionPreprocess
1  libobjc.A.dylib                0x1881ac55c objc_exception_throw
2  CoreFoundation                 0x189773c08 -[NSException name]
3  Foundation                     0x18a1bb0d8 -[NSKeyedArchiver _encodeArrayOfObjects:forKey:]
4  Foundation                     0x18a1b9c9c _encodeObject
5  Foundation                     0x18a1bb0f0 -[NSKeyedArchiver _encodeArrayOfObjects:forKey:]
6  Foundation                     0x18a1bad30 -[NSDictionary(NSDictionary) encodeWithCoder:]
7  Foundation                     0x18a1b9c9c _encodeObject
8  Foundation                     0x18a1c0b1c +[NSKeyedArchiver archivedDataWithRootObject:]
9  Countly                        0x100bd935c -[CountlyPersistency saveToFileSync] (CountlyPersistency.m:111)