### PR TITLE
[fixed] for 32-bit os, timestamp to long will be overflow.

### DIFF
--- a/CountlyCommon.m
+++ b/CountlyCommon.m
@@ -12,7 +12,7 @@
     NSCalendar* gregorianCalendar;
     NSTimeInterval startTime;
 }
-@property long lastTimestamp;
+@property long long lastTimestamp;
 @end
 
 NSString* const kCountlyParentDeviceIDTransferKey = @"kCountlyParentDeviceIDTransferKey";
@@ -70,7 +70,7 @@ NSString* const kCountlyParentDeviceIDTransferKey = @"kCountlyParentDeviceIDTran
 
 - (NSTimeInterval)uniqueTimestamp
 {
-    long now = floor(NSDate.date.timeIntervalSince1970 * 1000);
+    long long now = floor(NSDate.date.timeIntervalSince1970 * 1000);
 
     if(now <= self.lastTimestamp)
         self.lastTimestamp ++;
@@ -83,17 +83,17 @@ NSString* const kCountlyParentDeviceIDTransferKey = @"kCountlyParentDeviceIDTran
 - (NSString *)optionalParameters
 {
     NSMutableString *optinonalParameters = @"".mutableCopy;
-    
+
     if(self.ISOCountryCode)
         [optinonalParameters appendFormat:@"&country_code=%@", self.ISOCountryCode];
     if(self.city)
         [optinonalParameters appendFormat:@"&city=%@", self.city];
     if(self.location)
         [optinonalParameters appendFormat:@"&location=%@", self.location];
-    
+
     if(optinonalParameters.length)
         return optinonalParameters;
-    
+
     return nil;
 }
 

--- a/CountlyConnectionManager.m
+++ b/CountlyConnectionManager.m
@@ -286,10 +286,10 @@ NSString* const kCountlySDKName = @"objc-native-ios";
 
 - (NSString *)queryEssentials
 {
-    return [NSString stringWithFormat:@"app_key=%@&device_id=%@&timestamp=%ld&hour=%ld&dow=%ld&tz=%ld&sdk_version=%@&sdk_name=%@",
+    return [NSString stringWithFormat:@"app_key=%@&device_id=%@&timestamp=%lld&hour=%ld&dow=%ld&tz=%ld&sdk_version=%@&sdk_name=%@",
                                         self.appKey,
                                         CountlyDeviceInfo.sharedInstance.deviceID,
-                                        (long)(CountlyCommon.sharedInstance.uniqueTimestamp * 1000),
+                                        (long long)(CountlyCommon.sharedInstance.uniqueTimestamp * 1000),
                                         (long)CountlyCommon.sharedInstance.hourOfDay,
                                         (long)CountlyCommon.sharedInstance.dayOfWeek,
                                         (long)CountlyCommon.sharedInstance.timeZone,


### PR DESCRIPTION
For the 32-bit os, long type is 4 Bytes and the result will be overflow.