### PR TITLE
Fixed get file path form URL

### DIFF
--- a/CountlyPersistency.m
+++ b/CountlyPersistency.m
@@ -174,7 +174,7 @@ NSString* const kCountlyGeoLocationDisabledKey = @"kCountlyGeoLocationDisabledKe
 #endif
         NSError *error = nil;
 
-        if (![NSFileManager.defaultManager fileExistsAtPath:url.absoluteString])
+        if (![NSFileManager.defaultManager fileExistsAtPath:url.path])
         {
             [NSFileManager.defaultManager createDirectoryAtURL:url withIntermediateDirectories:YES attributes:nil error:&error];
             if (error){ COUNTLY_LOG(@"Application Support directory can not be created: \n%@", error); }


### PR DESCRIPTION
`url.absoluteString` should be `url.path`
https://stackoverflow.com/questions/34135305/nsfilemanager-defaultmanager-fileexistsatpath-returns-false-instead-of-true