### PR TITLE
Restore iOS 8 compatibility

### DIFF
--- a/Countly.h
+++ b/Countly.h
@@ -192,7 +192,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param options Bitwise combination of notification types (badge, sound or alert) the app wants to display
  * @param completionHandler A completion handler block to be executed when user answers notification permission dialog
  */
-- (void)askForNotificationPermissionWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError * error))completionHandler;
+- (void)askForNotificationPermissionWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError * error))completionHandler API_AVAILABLE(ios(10.0));
 
 /**
  * Records user's location to be used for geo-location based push notifications and advanced segmentation.

--- a/Countly.m
+++ b/Countly.m
@@ -399,15 +399,18 @@
 
 - (void)askForNotificationPermission
 {
-    UNAuthorizationOptions authorizationOptions = UNAuthorizationOptionBadge | UNAuthorizationOptionSound | UNAuthorizationOptionAlert;
-
-    [CountlyPushNotifications.sharedInstance askForNotificationPermissionWithOptions:authorizationOptions completionHandler:nil];
+    if (@available(iOS 10.0, *)) {
+        UNAuthorizationOptions authorizationOptions = UNAuthorizationOptionBadge | UNAuthorizationOptionSound | UNAuthorizationOptionAlert;
+        [CountlyPushNotifications.sharedInstance askForNotificationPermissionWithOptions:authorizationOptions completionHandler:nil];
+    } else {
+        UIUserNotificationType authorizationOptions = UIUserNotificationTypeBadge | UIUserNotificationTypeSound | UIUserNotificationTypeAlert;
+        [CountlyPushNotifications.sharedInstance askForNotificationPermissionWithLegacyOptions:authorizationOptions completionHandler:nil];
+    }
 }
 
 - (void)askForNotificationPermissionWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError * error))completionHandler;
 {
     [CountlyPushNotifications.sharedInstance askForNotificationPermissionWithOptions:options completionHandler:completionHandler];
-
 }
 
 - (void)recordLocation:(CLLocationCoordinate2D)location

--- a/CountlyCommon.m
+++ b/CountlyCommon.m
@@ -99,11 +99,15 @@ void CountlyInternalLog(NSString *format, ...)
     if (!self.enableAppleWatch)
         return;
 
-    if ([WCSession isSupported])
-    {
-        WCSession *session = WCSession.defaultSession;
-        session.delegate = (id<WCSessionDelegate>)self;
-        [session activateSession];
+    if (@available(iOS 9.0, *)) {
+        if ([WCSession isSupported])
+        {
+            WCSession *session = WCSession.defaultSession;
+            session.delegate = (id<WCSessionDelegate>)self;
+            [session activateSession];
+        }
+    } else {
+        COUNTLY_LOG(@"watchOS 1 (aka WatchKit) is not supported.");
     }
 }
 #endif
@@ -116,10 +120,14 @@ void CountlyInternalLog(NSString *format, ...)
 
     [self activateWatchConnectivity];
 
-    if (WCSession.defaultSession.paired && WCSession.defaultSession.watchAppInstalled)
-    {
-        [WCSession.defaultSession transferUserInfo:@{kCountlyParentDeviceIDTransferKey: CountlyDeviceInfo.sharedInstance.deviceID}];
-        COUNTLY_LOG(@"Transferring parent device ID %@ ...", CountlyDeviceInfo.sharedInstance.deviceID);
+    if (@available(iOS 9.0, *)) {
+        if (WCSession.defaultSession.paired && WCSession.defaultSession.watchAppInstalled)
+        {
+            [WCSession.defaultSession transferUserInfo:@{kCountlyParentDeviceIDTransferKey: CountlyDeviceInfo.sharedInstance.deviceID}];
+            COUNTLY_LOG(@"Transferring parent device ID %@ ...", CountlyDeviceInfo.sharedInstance.deviceID);
+        }
+    } else {
+        COUNTLY_LOG(@"watchOS 1 (aka WatchKit) is not supported.");
     }
 }
 #endif

--- a/CountlyDeviceInfo.m
+++ b/CountlyDeviceInfo.m
@@ -251,12 +251,22 @@ NSString* const kCountlyMetricKeyInstalledWatchApp  = @"_installed_watch_app";
 #if TARGET_OS_IOS
 + (NSInteger)hasWatch
 {
-    return (int)WCSession.defaultSession.paired;
+    if (@available(iOS 9.0, *)) {
+        return (int)WCSession.defaultSession.paired;
+    } else {
+        COUNTLY_LOG(@"watchOS 1 (aka WatchKit) is not supported.");
+        return 0;
+    }
 }
 
 + (NSInteger)installedWatchApp
 {
-    return (int)WCSession.defaultSession.watchAppInstalled;
+    if (@available(iOS 9.0, *)) {
+        return (int)WCSession.defaultSession.watchAppInstalled;
+    } else {
+        COUNTLY_LOG(@"watchOS 1 (aka WatchKit) is not supported.");
+        return 0;
+    }
 }
 #endif
 

--- a/CountlyNotificationService.h
+++ b/CountlyNotificationService.h
@@ -25,7 +25,7 @@ extern NSString* const kCountlyPNKeyActionButtonURL;
 
 @interface CountlyNotificationService : NSObject
 #if TARGET_OS_IOS
-+ (void)didReceiveNotificationRequest:(UNNotificationRequest *)request withContentHandler:(void (^)(UNNotificationContent *))contentHandler;
++ (void)didReceiveNotificationRequest:(UNNotificationRequest *)request withContentHandler:(void (^)(UNNotificationContent *))contentHandler API_AVAILABLE(ios(10.0));
 #endif
 
 NS_ASSUME_NONNULL_END

--- a/CountlyPushNotifications.h
+++ b/CountlyPushNotifications.h
@@ -26,6 +26,7 @@
 #if TARGET_OS_IOS
 - (void)startPushNotifications;
 - (void)askForNotificationPermissionWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError * error))completionHandler API_AVAILABLE(ios(10.0));
+- (void)askForNotificationPermissionWithLegacyOptions:(UIUserNotificationType)options completionHandler:(void (^)(BOOL granted, NSError * error))completionHandler;
 - (void)recordActionForNotification:(NSDictionary *)userInfo clickedButtonIndex:(NSInteger)buttonIndex;
 #endif
 @end

--- a/CountlyPushNotifications.h
+++ b/CountlyPushNotifications.h
@@ -25,7 +25,7 @@
 
 #if TARGET_OS_IOS
 - (void)startPushNotifications;
-- (void)askForNotificationPermissionWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError * error))completionHandler;
+- (void)askForNotificationPermissionWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError * error))completionHandler API_AVAILABLE(ios(10.0));
 - (void)recordActionForNotification:(NSDictionary *)userInfo clickedButtonIndex:(NSInteger)buttonIndex;
 #endif
 @end


### PR DESCRIPTION
Version 18.01 is annotated as compatible with [iOS 8.0](https://github.com/Countly/countly-sdk-ios/blob/master/Countly.podspec#L39). However, it uses the [UserNotifications](https://developer.apple.com/documentation/usernotifications) (added in iOS 10.0) and [WatchConnectivity](https://developer.apple.com/documentation/watchconnectivity) (added in iOS 9.0) frameworks. An easy way to fix this is to bump the minimum deployment target up to 10.0, however since [your docs](https://resources.count.ly/docs/countly-sdk-for-ios-and-os-x) call out **iOS 8.0**, I presume you want to retain support for these older versions of iOS.

⚠️ This PR uses the [`API_AVAILABLE` macro](https://developer.apple.com/library/content/releasenotes/Miscellaneous/RN-Foundation-OSX10.12/index.html) and [`@available`directive](https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW899) to address the API incompatabilities and get this library to compile when included in a project with a deployment target of iOS 8.0. These expressions were introduced with Xcode 9, so **this change makes the library no longer compatible with Xcode 8.0**.

Compiler error in Xcode 8:
<img width="785" alt="screen shot 2018-03-28 at 9 29 12 pm" src="https://user-images.githubusercontent.com/28851/38068565-1818dc48-32cf-11e8-9637-a2ae22cbb70b.png">


- Added `-askForNotificationPermissionWithLegacyOptions:completionHandler:completionHandler` for compatibility with older iOS versions that use `UIUserNotificationType`.
- Replaced `NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_9_x_Max` with `@available(iOS 10.0, *)`

These changes have not been tested on a device or in a working app yet. Also, there are no tests in this repo so I'm not sure how you go about validating changes. Xcode did most of the work and I wanted to propose this change and get your feedback before digging any deeper into making sure everything checks out.