### PR TITLE
Add a project file to enable Carthage support

### DIFF
--- a/Countly.xcodeproj/project.pbxproj
+++ b/Countly.xcodeproj/project.pbxproj
@@ -1,0 +1,471 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3B20A9872245225A00E3D7AE /* Countly.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9852245225A00E3D7AE /* Countly.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B20A9B22245228700E3D7AE /* CountlyConnectionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A98D2245228300E3D7AE /* CountlyConnectionManager.h */; };
+		3B20A9B32245228700E3D7AE /* CountlyNotificationService.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A98E2245228300E3D7AE /* CountlyNotificationService.m */; };
+		3B20A9B42245228700E3D7AE /* CountlyPushNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A98F2245228300E3D7AE /* CountlyPushNotifications.m */; };
+		3B20A9B52245228700E3D7AE /* CountlyCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9902245228300E3D7AE /* CountlyCommon.m */; };
+		3B20A9B62245228700E3D7AE /* CountlyAPMNetworkLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9912245228300E3D7AE /* CountlyAPMNetworkLog.m */; };
+		3B20A9B72245228700E3D7AE /* CountlyPersistency.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9922245228300E3D7AE /* CountlyPersistency.h */; };
+		3B20A9B82245228700E3D7AE /* CountlyAPM.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9932245228300E3D7AE /* CountlyAPM.h */; };
+		3B20A9B92245228700E3D7AE /* Countly.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9942245228400E3D7AE /* Countly.m */; };
+		3B20A9BA2245228700E3D7AE /* CountlyEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9952245228400E3D7AE /* CountlyEvent.m */; };
+		3B20A9BB2245228700E3D7AE /* CountlyAPM.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9962245228400E3D7AE /* CountlyAPM.m */; };
+		3B20A9BC2245228700E3D7AE /* CountlyCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9972245228400E3D7AE /* CountlyCommon.h */; };
+		3B20A9BD2245228700E3D7AE /* CountlyConnectionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9982245228400E3D7AE /* CountlyConnectionManager.m */; };
+		3B20A9BE2245228700E3D7AE /* CountlyDeviceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9992245228400E3D7AE /* CountlyDeviceInfo.h */; };
+		3B20A9BF2245228700E3D7AE /* CountlyLocationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A99A2245228400E3D7AE /* CountlyLocationManager.h */; };
+		3B20A9C02245228700E3D7AE /* CountlyConsentManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A99B2245228400E3D7AE /* CountlyConsentManager.m */; };
+		3B20A9C12245228700E3D7AE /* CountlyRemoteConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A99C2245228400E3D7AE /* CountlyRemoteConfig.h */; };
+		3B20A9C22245228700E3D7AE /* Countly_OpenUDID.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A99D2245228400E3D7AE /* Countly_OpenUDID.h */; };
+		3B20A9C32245228700E3D7AE /* CountlyEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A99E2245228400E3D7AE /* CountlyEvent.h */; };
+		3B20A9C42245228700E3D7AE /* CountlyUserDetails.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A99F2245228400E3D7AE /* CountlyUserDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B20A9C52245228700E3D7AE /* CountlyCrashReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9A02245228400E3D7AE /* CountlyCrashReporter.h */; };
+		3B20A9C62245228700E3D7AE /* CountlyStarRating.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9A12245228500E3D7AE /* CountlyStarRating.m */; };
+		3B20A9C72245228700E3D7AE /* CountlyNotificationService.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9A22245228500E3D7AE /* CountlyNotificationService.h */; };
+		3B20A9C82245228700E3D7AE /* CountlyViewTracking.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9A32245228500E3D7AE /* CountlyViewTracking.m */; };
+		3B20A9C92245228700E3D7AE /* CountlyUserDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9A42245228500E3D7AE /* CountlyUserDetails.m */; };
+		3B20A9CA2245228700E3D7AE /* CountlyConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9A52245228500E3D7AE /* CountlyConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3B20A9CB2245228700E3D7AE /* CountlyRemoteConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9A62245228500E3D7AE /* CountlyRemoteConfig.m */; };
+		3B20A9CC2245228700E3D7AE /* CountlyViewTracking.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9A72245228500E3D7AE /* CountlyViewTracking.h */; };
+		3B20A9CD2245228700E3D7AE /* CountlyAPMNetworkLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9A82245228500E3D7AE /* CountlyAPMNetworkLog.h */; };
+		3B20A9CE2245228700E3D7AE /* CountlyCrashReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9A92245228500E3D7AE /* CountlyCrashReporter.m */; };
+		3B20A9CF2245228700E3D7AE /* CountlyDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9AA2245228500E3D7AE /* CountlyDeviceInfo.m */; };
+		3B20A9D02245228700E3D7AE /* CountlyStarRating.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9AB2245228600E3D7AE /* CountlyStarRating.h */; };
+		3B20A9D12245228700E3D7AE /* CountlyConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9AC2245228600E3D7AE /* CountlyConfig.m */; };
+		3B20A9D22245228700E3D7AE /* CountlyLocationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9AD2245228600E3D7AE /* CountlyLocationManager.m */; };
+		3B20A9D32245228700E3D7AE /* CountlyPushNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9AE2245228600E3D7AE /* CountlyPushNotifications.h */; };
+		3B20A9D42245228700E3D7AE /* CountlyPersistency.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9AF2245228600E3D7AE /* CountlyPersistency.m */; };
+		3B20A9D52245228700E3D7AE /* Countly_OpenUDID.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B20A9B02245228700E3D7AE /* Countly_OpenUDID.m */; };
+		3B20A9D62245228700E3D7AE /* CountlyConsentManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B20A9B12245228700E3D7AE /* CountlyConsentManager.h */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		3B20A9822245225A00E3D7AE /* Countly.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Countly.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B20A9852245225A00E3D7AE /* Countly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Countly.h; sourceTree = "<group>"; };
+		3B20A9862245225A00E3D7AE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3B20A98D2245228300E3D7AE /* CountlyConnectionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyConnectionManager.h; sourceTree = "<group>"; };
+		3B20A98E2245228300E3D7AE /* CountlyNotificationService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyNotificationService.m; sourceTree = "<group>"; };
+		3B20A98F2245228300E3D7AE /* CountlyPushNotifications.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyPushNotifications.m; sourceTree = "<group>"; };
+		3B20A9902245228300E3D7AE /* CountlyCommon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyCommon.m; sourceTree = "<group>"; };
+		3B20A9912245228300E3D7AE /* CountlyAPMNetworkLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyAPMNetworkLog.m; sourceTree = "<group>"; };
+		3B20A9922245228300E3D7AE /* CountlyPersistency.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyPersistency.h; sourceTree = "<group>"; };
+		3B20A9932245228300E3D7AE /* CountlyAPM.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyAPM.h; sourceTree = "<group>"; };
+		3B20A9942245228400E3D7AE /* Countly.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Countly.m; sourceTree = "<group>"; };
+		3B20A9952245228400E3D7AE /* CountlyEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyEvent.m; sourceTree = "<group>"; };
+		3B20A9962245228400E3D7AE /* CountlyAPM.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyAPM.m; sourceTree = "<group>"; };
+		3B20A9972245228400E3D7AE /* CountlyCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyCommon.h; sourceTree = "<group>"; };
+		3B20A9982245228400E3D7AE /* CountlyConnectionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyConnectionManager.m; sourceTree = "<group>"; };
+		3B20A9992245228400E3D7AE /* CountlyDeviceInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyDeviceInfo.h; sourceTree = "<group>"; };
+		3B20A99A2245228400E3D7AE /* CountlyLocationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyLocationManager.h; sourceTree = "<group>"; };
+		3B20A99B2245228400E3D7AE /* CountlyConsentManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyConsentManager.m; sourceTree = "<group>"; };
+		3B20A99C2245228400E3D7AE /* CountlyRemoteConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyRemoteConfig.h; sourceTree = "<group>"; };
+		3B20A99D2245228400E3D7AE /* Countly_OpenUDID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Countly_OpenUDID.h; sourceTree = "<group>"; };
+		3B20A99E2245228400E3D7AE /* CountlyEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyEvent.h; sourceTree = "<group>"; };
+		3B20A99F2245228400E3D7AE /* CountlyUserDetails.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyUserDetails.h; sourceTree = "<group>"; };
+		3B20A9A02245228400E3D7AE /* CountlyCrashReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyCrashReporter.h; sourceTree = "<group>"; };
+		3B20A9A12245228500E3D7AE /* CountlyStarRating.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyStarRating.m; sourceTree = "<group>"; };
+		3B20A9A22245228500E3D7AE /* CountlyNotificationService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyNotificationService.h; sourceTree = "<group>"; };
+		3B20A9A32245228500E3D7AE /* CountlyViewTracking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyViewTracking.m; sourceTree = "<group>"; };
+		3B20A9A42245228500E3D7AE /* CountlyUserDetails.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyUserDetails.m; sourceTree = "<group>"; };
+		3B20A9A52245228500E3D7AE /* CountlyConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyConfig.h; sourceTree = "<group>"; };
+		3B20A9A62245228500E3D7AE /* CountlyRemoteConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyRemoteConfig.m; sourceTree = "<group>"; };
+		3B20A9A72245228500E3D7AE /* CountlyViewTracking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyViewTracking.h; sourceTree = "<group>"; };
+		3B20A9A82245228500E3D7AE /* CountlyAPMNetworkLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyAPMNetworkLog.h; sourceTree = "<group>"; };
+		3B20A9A92245228500E3D7AE /* CountlyCrashReporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyCrashReporter.m; sourceTree = "<group>"; };
+		3B20A9AA2245228500E3D7AE /* CountlyDeviceInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyDeviceInfo.m; sourceTree = "<group>"; };
+		3B20A9AB2245228600E3D7AE /* CountlyStarRating.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyStarRating.h; sourceTree = "<group>"; };
+		3B20A9AC2245228600E3D7AE /* CountlyConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyConfig.m; sourceTree = "<group>"; };
+		3B20A9AD2245228600E3D7AE /* CountlyLocationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyLocationManager.m; sourceTree = "<group>"; };
+		3B20A9AE2245228600E3D7AE /* CountlyPushNotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyPushNotifications.h; sourceTree = "<group>"; };
+		3B20A9AF2245228600E3D7AE /* CountlyPersistency.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CountlyPersistency.m; sourceTree = "<group>"; };
+		3B20A9B02245228700E3D7AE /* Countly_OpenUDID.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Countly_OpenUDID.m; sourceTree = "<group>"; };
+		3B20A9B12245228700E3D7AE /* CountlyConsentManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CountlyConsentManager.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3B20A97F2245225A00E3D7AE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3B20A9782245225A00E3D7AE = {
+			isa = PBXGroup;
+			children = (
+				3B20A99D2245228400E3D7AE /* Countly_OpenUDID.h */,
+				3B20A9B02245228700E3D7AE /* Countly_OpenUDID.m */,
+				3B20A9852245225A00E3D7AE /* Countly.h */,
+				3B20A9942245228400E3D7AE /* Countly.m */,
+				3B20A9932245228300E3D7AE /* CountlyAPM.h */,
+				3B20A9962245228400E3D7AE /* CountlyAPM.m */,
+				3B20A9A82245228500E3D7AE /* CountlyAPMNetworkLog.h */,
+				3B20A9912245228300E3D7AE /* CountlyAPMNetworkLog.m */,
+				3B20A9972245228400E3D7AE /* CountlyCommon.h */,
+				3B20A9902245228300E3D7AE /* CountlyCommon.m */,
+				3B20A9A52245228500E3D7AE /* CountlyConfig.h */,
+				3B20A9AC2245228600E3D7AE /* CountlyConfig.m */,
+				3B20A98D2245228300E3D7AE /* CountlyConnectionManager.h */,
+				3B20A9982245228400E3D7AE /* CountlyConnectionManager.m */,
+				3B20A9B12245228700E3D7AE /* CountlyConsentManager.h */,
+				3B20A99B2245228400E3D7AE /* CountlyConsentManager.m */,
+				3B20A9A02245228400E3D7AE /* CountlyCrashReporter.h */,
+				3B20A9A92245228500E3D7AE /* CountlyCrashReporter.m */,
+				3B20A9992245228400E3D7AE /* CountlyDeviceInfo.h */,
+				3B20A9AA2245228500E3D7AE /* CountlyDeviceInfo.m */,
+				3B20A99E2245228400E3D7AE /* CountlyEvent.h */,
+				3B20A9952245228400E3D7AE /* CountlyEvent.m */,
+				3B20A99A2245228400E3D7AE /* CountlyLocationManager.h */,
+				3B20A9AD2245228600E3D7AE /* CountlyLocationManager.m */,
+				3B20A9A22245228500E3D7AE /* CountlyNotificationService.h */,
+				3B20A98E2245228300E3D7AE /* CountlyNotificationService.m */,
+				3B20A9922245228300E3D7AE /* CountlyPersistency.h */,
+				3B20A9AF2245228600E3D7AE /* CountlyPersistency.m */,
+				3B20A9AE2245228600E3D7AE /* CountlyPushNotifications.h */,
+				3B20A98F2245228300E3D7AE /* CountlyPushNotifications.m */,
+				3B20A99C2245228400E3D7AE /* CountlyRemoteConfig.h */,
+				3B20A9A62245228500E3D7AE /* CountlyRemoteConfig.m */,
+				3B20A9AB2245228600E3D7AE /* CountlyStarRating.h */,
+				3B20A9A12245228500E3D7AE /* CountlyStarRating.m */,
+				3B20A99F2245228400E3D7AE /* CountlyUserDetails.h */,
+				3B20A9A42245228500E3D7AE /* CountlyUserDetails.m */,
+				3B20A9A72245228500E3D7AE /* CountlyViewTracking.h */,
+				3B20A9A32245228500E3D7AE /* CountlyViewTracking.m */,
+				3B20A9862245225A00E3D7AE /* Info.plist */,
+				3B20A9832245225A00E3D7AE /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3B20A9832245225A00E3D7AE /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3B20A9822245225A00E3D7AE /* Countly.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		3B20A97D2245225A00E3D7AE /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3B20A9D32245228700E3D7AE /* CountlyPushNotifications.h in Headers */,
+				3B20A9C42245228700E3D7AE /* CountlyUserDetails.h in Headers */,
+				3B20A9CA2245228700E3D7AE /* CountlyConfig.h in Headers */,
+				3B20A9872245225A00E3D7AE /* Countly.h in Headers */,
+				3B20A9B22245228700E3D7AE /* CountlyConnectionManager.h in Headers */,
+				3B20A9CC2245228700E3D7AE /* CountlyViewTracking.h in Headers */,
+				3B20A9BF2245228700E3D7AE /* CountlyLocationManager.h in Headers */,
+				3B20A9CD2245228700E3D7AE /* CountlyAPMNetworkLog.h in Headers */,
+				3B20A9C12245228700E3D7AE /* CountlyRemoteConfig.h in Headers */,
+				3B20A9BC2245228700E3D7AE /* CountlyCommon.h in Headers */,
+				3B20A9C52245228700E3D7AE /* CountlyCrashReporter.h in Headers */,
+				3B20A9BE2245228700E3D7AE /* CountlyDeviceInfo.h in Headers */,
+				3B20A9D62245228700E3D7AE /* CountlyConsentManager.h in Headers */,
+				3B20A9D02245228700E3D7AE /* CountlyStarRating.h in Headers */,
+				3B20A9C32245228700E3D7AE /* CountlyEvent.h in Headers */,
+				3B20A9B82245228700E3D7AE /* CountlyAPM.h in Headers */,
+				3B20A9C72245228700E3D7AE /* CountlyNotificationService.h in Headers */,
+				3B20A9B72245228700E3D7AE /* CountlyPersistency.h in Headers */,
+				3B20A9C22245228700E3D7AE /* Countly_OpenUDID.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		3B20A9812245225A00E3D7AE /* Countly */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3B20A98A2245225A00E3D7AE /* Build configuration list for PBXNativeTarget "Countly" */;
+			buildPhases = (
+				3B20A97D2245225A00E3D7AE /* Headers */,
+				3B20A97E2245225A00E3D7AE /* Sources */,
+				3B20A97F2245225A00E3D7AE /* Frameworks */,
+				3B20A9802245225A00E3D7AE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Countly;
+			productName = Countly;
+			productReference = 3B20A9822245225A00E3D7AE /* Countly.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3B20A9792245225A00E3D7AE /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1010;
+				ORGANIZATIONNAME = "Alin Radut";
+				TargetAttributes = {
+					3B20A9812245225A00E3D7AE = {
+						CreatedOnToolsVersion = 10.1;
+					};
+				};
+			};
+			buildConfigurationList = 3B20A97C2245225A00E3D7AE /* Build configuration list for PBXProject "Countly" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 3B20A9782245225A00E3D7AE;
+			productRefGroup = 3B20A9832245225A00E3D7AE /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3B20A9812245225A00E3D7AE /* Countly */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3B20A9802245225A00E3D7AE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3B20A97E2245225A00E3D7AE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3B20A9B92245228700E3D7AE /* Countly.m in Sources */,
+				3B20A9BA2245228700E3D7AE /* CountlyEvent.m in Sources */,
+				3B20A9B52245228700E3D7AE /* CountlyCommon.m in Sources */,
+				3B20A9CF2245228700E3D7AE /* CountlyDeviceInfo.m in Sources */,
+				3B20A9CE2245228700E3D7AE /* CountlyCrashReporter.m in Sources */,
+				3B20A9BB2245228700E3D7AE /* CountlyAPM.m in Sources */,
+				3B20A9D42245228700E3D7AE /* CountlyPersistency.m in Sources */,
+				3B20A9B62245228700E3D7AE /* CountlyAPMNetworkLog.m in Sources */,
+				3B20A9D52245228700E3D7AE /* Countly_OpenUDID.m in Sources */,
+				3B20A9B32245228700E3D7AE /* CountlyNotificationService.m in Sources */,
+				3B20A9CB2245228700E3D7AE /* CountlyRemoteConfig.m in Sources */,
+				3B20A9BD2245228700E3D7AE /* CountlyConnectionManager.m in Sources */,
+				3B20A9C02245228700E3D7AE /* CountlyConsentManager.m in Sources */,
+				3B20A9B42245228700E3D7AE /* CountlyPushNotifications.m in Sources */,
+				3B20A9C62245228700E3D7AE /* CountlyStarRating.m in Sources */,
+				3B20A9C92245228700E3D7AE /* CountlyUserDetails.m in Sources */,
+				3B20A9D12245228700E3D7AE /* CountlyConfig.m in Sources */,
+				3B20A9C82245228700E3D7AE /* CountlyViewTracking.m in Sources */,
+				3B20A9D22245228700E3D7AE /* CountlyLocationManager.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		3B20A9882245225A00E3D7AE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3B20A9892245225A00E3D7AE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		3B20A98B2245225A00E3D7AE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = UK846DSPM6;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = ly.count.Countly;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3B20A98C2245225A00E3D7AE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = UK846DSPM6;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = ly.count.Countly;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3B20A97C2245225A00E3D7AE /* Build configuration list for PBXProject "Countly" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3B20A9882245225A00E3D7AE /* Debug */,
+				3B20A9892245225A00E3D7AE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3B20A98A2245225A00E3D7AE /* Build configuration list for PBXNativeTarget "Countly" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3B20A98B2245225A00E3D7AE /* Debug */,
+				3B20A98C2245225A00E3D7AE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3B20A9792245225A00E3D7AE /* Project object */;
+}

--- a/Countly.xcodeproj/project.pbxproj
+++ b/Countly.xcodeproj/project.pbxproj
@@ -398,15 +398,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = UK846DSPM6;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -414,6 +414,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ly.count.Countly;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -423,15 +424,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = UK846DSPM6;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -439,6 +440,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ly.count.Countly;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Countly.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Countly.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Countly.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Countly.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Countly.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Countly.xcodeproj/xcshareddata/xcschemes/Countly.xcscheme
+++ b/Countly.xcodeproj/xcshareddata/xcschemes/Countly.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3B20A9812245225A00E3D7AE"
+               BuildableName = "Countly.framework"
+               BlueprintName = "Countly"
+               ReferencedContainer = "container:Countly.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3B20A9812245225A00E3D7AE"
+            BuildableName = "Countly.framework"
+            BlueprintName = "Countly"
+            ReferencedContainer = "container:Countly.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3B20A9812245225A00E3D7AE"
+            BuildableName = "Countly.framework"
+            BlueprintName = "Countly"
+            ReferencedContainer = "container:Countly.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>


### PR DESCRIPTION
Added a project file that allows Carthage to build the library as a framework. The deployment target is set to 8.0 and the bundle identifier to ly.count.Countly. Signing is left to manual with no profiles selected. The only public headers are 'Countly.h', 'CountlyUserDetails.h', 'CountlyConfig.h'.

Reasoning: the advantage of using a standalone framework file is faster build times. This is of course not an issue on smaller projects, but for larger projects I like to keep external libraries as prebuilt frameworks in order to squeeze any second out of the build time.


