### PR TITLE
Allow recording events before Countly has started

### DIFF
--- a/CountlyPersistency.m
+++ b/CountlyPersistency.m
@@ -23,8 +23,6 @@ NSString* const kCountlyRemoteConfigPersistencyKey = @"kCountlyRemoteConfigPersi
 
 + (instancetype)sharedInstance
 {
-    if (!CountlyCommon.sharedInstance.hasStarted)
-        return nil;
 
     static CountlyPersistency* s_sharedInstance = nil;
     static dispatch_once_t onceToken;
@@ -65,7 +63,7 @@ NSString* const kCountlyRemoteConfigPersistencyKey = @"kCountlyRemoteConfigPersi
     {
         [self.queuedRequests addObject:queryString];
 
-        if (self.queuedRequests.count > self.storedRequestsLimit && !CountlyConnectionManager.sharedInstance.connection)
+        if (self.queuedRequests.count > self.storedRequestsLimit && CountlyConnectionManager.sharedInstance.connection == nil)
             [self.queuedRequests removeObjectAtIndex:0];
     }
 }
@@ -95,7 +93,7 @@ NSString* const kCountlyRemoteConfigPersistencyKey = @"kCountlyRemoteConfigPersi
     {
         [self.recordedEvents addObject:event];
 
-        if (self.recordedEvents.count >= self.eventSendThreshold)
+        if (self.recordedEvents.count >= self.eventSendThreshold && CountlyConnectionManager.sharedInstance != nil)
             [CountlyConnectionManager.sharedInstance sendEvents];
     }
 }


### PR DESCRIPTION
In our use case, we may not be ready to start Countly until some time
after the app has started, since we fetch the appropriate app key and
URL asynchronously. However, we would still like to record events during
this time.

As it turns out, there are no insurmountable obstacles to doing so. We
can just fill the queue until it overflows or until Countly has started.