### PR TITLE
declare crashSegmentation key type as NSString

### DIFF
--- a/CountlyConfig.h
+++ b/CountlyConfig.h
@@ -220,7 +220,7 @@ extern NSString* const CLYConsentAppleWatch;
 /**
  * For using custom crash segmentation with @c CLYCrashReporting feature.
  */
-@property (nonatomic, copy) NSDictionary* crashSegmentation;
+@property (nonatomic, copy) NSDictionary<NSString*, id>* crashSegmentation;
 
 /**
  * Crash log limit is used for limiting the number of crash logs to be stored on the device.

--- a/CountlyCrashReporter.h
+++ b/CountlyCrashReporter.h
@@ -9,7 +9,7 @@
 @interface CountlyCrashReporter : NSObject
 #if TARGET_OS_IOS
 @property (nonatomic) BOOL isEnabledOnInitialConfig;
-@property (nonatomic) NSDictionary* crashSegmentation;
+@property (nonatomic) NSDictionary<NSString*, id>* crashSegmentation;
 @property (nonatomic) NSUInteger crashLogLimit;
 
 + (instancetype)sharedInstance;


### PR DESCRIPTION
We had a bug in our Swift code where we set this dictionary to a literal that contained an enum case as its key, where the enum is a String raw type, but accidentally omitted the `.rawValue` call. The code compiled but crash reports could not be generated, presumably due to some further secondary crash in the report generation code.

We tested this change against our buggy code and confirmed it no longer compiles, so this type safety is a useful sanity check against what's being provided to the `crashSegmentation` dictionary property.