### PR TITLE
fix: Used the API that does not automatically adds the timer to the current run loop

### DIFF
--- a/Countly.m
+++ b/Countly.m
@@ -141,7 +141,11 @@
 //    if ([config.features containsObject:CLYAPM])
 //        [CountlyAPM.sharedInstance startAPM];
 
-    timer = [NSTimer scheduledTimerWithTimeInterval:config.updateSessionPeriod target:self selector:@selector(onTimer:) userInfo:nil repeats:YES];
+    timer = [NSTimer timerWithTimeInterval:config.updateSessionPeriod
+                                    target:self
+                                  selector:@selector(onTimer:)
+                                  userInfo:nil
+                                   repeats:YES];
     [NSRunLoop.mainRunLoop addTimer:timer forMode:NSRunLoopCommonModes];
 
     [CountlyCommon.sharedInstance startAppleWatchMatching];


### PR DESCRIPTION
### Description

Addressed https://github.com/Countly/countly-sdk-ios/issues/145