### PR TITLE
Add a preprocessor flag to exclude push notifications.

### DIFF
--- a/Countly.h
+++ b/Countly.h
@@ -9,7 +9,9 @@
 #import "CountlyUserDetails.h"
 #import "CountlyConfig.h"
 #if (TARGET_OS_IOS || TARGET_OS_OSX)
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 #import <UserNotifications/UserNotifications.h>
+#endif
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
@@ -282,6 +284,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Push Notification
 #if (TARGET_OS_IOS || TARGET_OS_OSX)
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 /**
  * Shows default system dialog that asks for user's permission to display notifications.
  * @discussion A unified convenience method that handles asking for notification permission on both iOS10 and older iOS versions with badge, sound and alert notification types.
@@ -321,7 +324,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)clearPushNotificationToken;
 #endif
-
+#endif
 
 
 #pragma mark - Location

--- a/Countly.m
+++ b/Countly.m
@@ -118,6 +118,7 @@
 #endif
 
 #if (TARGET_OS_IOS || TARGET_OS_OSX)
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
     if ([config.features containsObject:CLYPushNotifications])
     {
         CountlyPushNotifications.sharedInstance.isEnabledOnInitialConfig = YES;
@@ -127,6 +128,7 @@
         CountlyPushNotifications.sharedInstance.launchNotification = config.launchNotification;
         [CountlyPushNotifications.sharedInstance startPushNotifications];
     }
+#endif
 #endif
 
 #if (TARGET_OS_IOS || TARGET_OS_TV)
@@ -536,6 +538,7 @@
 
 #pragma mark - Push Notifications
 #if (TARGET_OS_IOS || TARGET_OS_OSX)
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 
 - (void)askForNotificationPermission
 {
@@ -561,6 +564,7 @@
 {
     [CountlyPushNotifications.sharedInstance clearToken];
 }
+#endif
 #endif
 
 

--- a/CountlyConfig.h
+++ b/CountlyConfig.h
@@ -10,13 +10,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 //NOTE: Countly features
 #if TARGET_OS_IOS
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 extern NSString* const CLYPushNotifications;
+#endif
 extern NSString* const CLYCrashReporting;
 extern NSString* const CLYAutoViewTracking;
 #elif TARGET_OS_TV
 extern NSString* const CLYAutoViewTracking;
 #elif TARGET_OS_OSX
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 extern NSString* const CLYPushNotifications;
+#endif
 #endif
 
 
@@ -48,7 +52,9 @@ extern NSString* const CLYConsentSessions;
 extern NSString* const CLYConsentEvents;
 extern NSString* const CLYConsentUserDetails;
 extern NSString* const CLYConsentCrashReporting;
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 extern NSString* const CLYConsentPushNotifications;
+#endif
 extern NSString* const CLYConsentLocation;
 extern NSString* const CLYConsentViewTracking;
 extern NSString* const CLYConsentAttribution;
@@ -56,8 +62,10 @@ extern NSString* const CLYConsentStarRating;
 extern NSString* const CLYConsentAppleWatch;
 
 //NOTE: Push Notification Test Modes
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 extern NSString* const CLYPushTestModeDevelopment;
 extern NSString* const CLYPushTestModeTestFlightOrAdHoc;
+#endif
 
 @interface CountlyConfig : NSObject
 
@@ -104,6 +112,7 @@ extern NSString* const CLYPushTestModeTestFlightOrAdHoc;
 
 #pragma mark -
 
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 /**
  * @c isTestDevice property is deprecated. Please use @c pushTestMode property instead.
  * @discussion Using this property will have no effect.
@@ -137,6 +146,7 @@ extern NSString* const CLYPushTestModeTestFlightOrAdHoc;
  * @discussion Needs to be set in @c applicationDidFinishLaunching: method of macOS apps that uses @c CLYPushNotifications feature, in order to handle app launches by push notification click.
  */
 @property (nonatomic) NSNotification* launchNotification;
+#endif
 
 #pragma mark -
 

--- a/CountlyConfig.m
+++ b/CountlyConfig.m
@@ -10,13 +10,17 @@
 
 //NOTE: Countly features
 #if TARGET_OS_IOS
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
     NSString* const CLYPushNotifications = @"CLYPushNotifications";
+#endif
     NSString* const CLYCrashReporting = @"CLYCrashReporting";
     NSString* const CLYAutoViewTracking = @"CLYAutoViewTracking";
 #elif TARGET_OS_TV
     NSString* const CLYAutoViewTracking = @"CLYAutoViewTracking";
 #elif TARGET_OS_OSX
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
     NSString* const CLYPushNotifications = @"CLYPushNotifications";
+#endif
 #endif
 
 

--- a/CountlyConnectionManager.h
+++ b/CountlyConnectionManager.h
@@ -30,7 +30,9 @@ extern NSString* const kCountlyQSKeyDeviceID;
 - (void)endSession;
 
 - (void)sendEvents;
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 - (void)sendPushToken:(NSString *)token;
+#endif
 - (void)sendLocationInfo;
 - (void)sendUserDetails:(NSString *)userDetails;
 - (void)sendCrashReport:(NSString *)report immediately:(BOOL)immediately;

--- a/CountlyConnectionManager.m
+++ b/CountlyConnectionManager.m
@@ -32,9 +32,11 @@ NSString* const kCountlyQSKeySessionBegin     = @"begin_session";
 NSString* const kCountlyQSKeySessionDuration  = @"session_duration";
 NSString* const kCountlyQSKeySessionEnd       = @"end_session";
 
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 NSString* const kCountlyQSKeyPushTokenSession = @"token_session";
 NSString* const kCountlyQSKeyPushTokeniOS     = @"ios_token";
 NSString* const kCountlyQSKeyPushTestMode     = @"test_mode";
+#endif
 
 NSString* const kCountlyQSKeyLocation         = @"location";
 NSString* const kCountlyQSKeyLocationCity     = @"city";
@@ -245,6 +247,7 @@ const NSInteger kCountlyGETRequestMaxLength = 2048;
 
 #pragma mark ---
 
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 - (void)sendPushToken:(NSString *)token
 {
     NSInteger testMode = 0; //NOTE: default is 0: Production - not test mode
@@ -263,6 +266,7 @@ const NSInteger kCountlyGETRequestMaxLength = 2048;
 
     [self proceedOnQueue];
 }
+#endif
 
 - (void)sendLocationInfo
 {

--- a/CountlyConsentManager.h
+++ b/CountlyConsentManager.h
@@ -14,7 +14,9 @@
 @property (nonatomic, readonly) BOOL consentForEvents;
 @property (nonatomic, readonly) BOOL consentForUserDetails;
 @property (nonatomic, readonly) BOOL consentForCrashReporting;
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 @property (nonatomic, readonly) BOOL consentForPushNotifications;
+#endif
 @property (nonatomic, readonly) BOOL consentForLocation;
 @property (nonatomic, readonly) BOOL consentForViewTracking;
 @property (nonatomic, readonly) BOOL consentForAttribution;

--- a/CountlyConsentManager.m
+++ b/CountlyConsentManager.m
@@ -10,7 +10,9 @@ NSString* const CLYConsentSessions             = @"sessions";
 NSString* const CLYConsentEvents               = @"events";
 NSString* const CLYConsentUserDetails          = @"users";
 NSString* const CLYConsentCrashReporting       = @"crashes";
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 NSString* const CLYConsentPushNotifications    = @"push";
+#endif
 NSString* const CLYConsentLocation             = @"location";
 NSString* const CLYConsentViewTracking         = @"views";
 NSString* const CLYConsentAttribution          = @"attribution";
@@ -28,7 +30,9 @@ NSString* const CLYConsentAppleWatch           = @"accessory-devices";
 @synthesize consentForEvents = _consentForEvents;
 @synthesize consentForUserDetails = _consentForUserDetails;
 @synthesize consentForCrashReporting = _consentForCrashReporting;
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 @synthesize consentForPushNotifications = _consentForPushNotifications;
+#endif
 @synthesize consentForLocation = _consentForLocation;
 @synthesize consentForViewTracking = _consentForViewTracking;
 @synthesize consentForAttribution = _consentForAttribution;
@@ -89,8 +93,10 @@ NSString* const CLYConsentAppleWatch           = @"accessory-devices";
     if ([features containsObject:CLYConsentCrashReporting] && !self.consentForCrashReporting)
         self.consentForCrashReporting = YES;
 
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
     if ([features containsObject:CLYConsentPushNotifications] && !self.consentForPushNotifications)
         self.consentForPushNotifications = YES;
+#endif
 
     if ([features containsObject:CLYConsentLocation] && !self.consentForLocation)
         self.consentForLocation = YES;
@@ -134,8 +140,10 @@ NSString* const CLYConsentAppleWatch           = @"accessory-devices";
     if ([features containsObject:CLYConsentCrashReporting] && self.consentForCrashReporting)
         self.consentForCrashReporting = NO;
 
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
     if ([features containsObject:CLYConsentPushNotifications] && self.consentForPushNotifications)
         self.consentForPushNotifications = NO;
+#endif
 
     if ([features containsObject:CLYConsentLocation] && self.consentForLocation)
         self.consentForLocation = NO;
@@ -174,7 +182,9 @@ NSString* const CLYConsentAppleWatch           = @"accessory-devices";
         CLYConsentEvents,
         CLYConsentUserDetails,
         CLYConsentCrashReporting,
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
         CLYConsentPushNotifications,
+#endif
         CLYConsentLocation,
         CLYConsentViewTracking,
         CLYConsentAttribution,
@@ -191,7 +201,9 @@ NSString* const CLYConsentAppleWatch           = @"accessory-devices";
     self.consentForEvents ||
     self.consentForUserDetails ||
     self.consentForCrashReporting ||
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
     self.consentForPushNotifications ||
+#endif
     self.consentForLocation ||
     self.consentForViewTracking ||
     self.consentForAttribution ||
@@ -284,7 +296,7 @@ NSString* const CLYConsentAppleWatch           = @"accessory-devices";
     self.consentChanges[CLYConsentCrashReporting] = @(consentForCrashReporting);
 }
 
-
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 - (void)setConsentForPushNotifications:(BOOL)consentForPushNotifications
 {
     _consentForPushNotifications = consentForPushNotifications;
@@ -306,7 +318,7 @@ NSString* const CLYConsentAppleWatch           = @"accessory-devices";
 
     self.consentChanges[CLYConsentPushNotifications] = @(consentForPushNotifications);
 }
-
+#endif
 
 - (void)setConsentForLocation:(BOOL)consentForLocation
 {
@@ -447,7 +459,7 @@ NSString* const CLYConsentAppleWatch           = @"accessory-devices";
     return _consentForCrashReporting;
 }
 
-
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 - (BOOL)consentForPushNotifications
 {
     if (!self.requiresConsent)
@@ -455,7 +467,7 @@ NSString* const CLYConsentAppleWatch           = @"accessory-devices";
 
     return _consentForPushNotifications;
 }
-
+#endif
 
 - (BOOL)consentForLocation
 {

--- a/CountlyNotificationService.h
+++ b/CountlyNotificationService.h
@@ -6,6 +6,7 @@
 
 #import <Foundation/Foundation.h>
 
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 #if TARGET_OS_IOS
 #import <UserNotifications/UserNotifications.h>
 #endif
@@ -31,3 +32,4 @@ extern NSString* const kCountlyPNKeyActionButtonURL;
 NS_ASSUME_NONNULL_END
 
 @end
+#endif

--- a/CountlyNotificationService.m
+++ b/CountlyNotificationService.m
@@ -6,6 +6,7 @@
 
 #import "CountlyNotificationService.h"
 
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 #if DEBUG
 #define COUNTLY_EXT_LOG(fmt, ...) NSLog([@"%@ " stringByAppendingString:fmt], @"[CountlyNSE]", ##__VA_ARGS__)
 #else
@@ -124,3 +125,4 @@ NSString* const kCountlyPNKeyActionButtonURL    = @"l";
 }
 #endif
 @end
+#endif

--- a/CountlyPushNotifications.h
+++ b/CountlyPushNotifications.h
@@ -6,6 +6,7 @@
 
 #import <Foundation/Foundation.h>
 
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 @interface CountlyPushNotifications : NSObject
 
 @property (nonatomic) BOOL isEnabledOnInitialConfig;
@@ -25,3 +26,4 @@
 - (void)clearToken;
 #endif
 @end
+#endif

--- a/CountlyPushNotifications.m
+++ b/CountlyPushNotifications.m
@@ -6,6 +6,7 @@
 
 #import "CountlyCommon.h"
 
+#ifndef COUNTLY_EXCLUDE_USERNOTIFICATIONS
 NSString* const kCountlyReservedEventPushAction = @"[CLY]_push_action";
 NSString* const kCountlyTokenError = @"kCountlyTokenError";
 
@@ -565,3 +566,4 @@ NSString* const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFlightOr
 
 @end
 #pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
This avoids iOS apps needing to have the push notification
entitlement just to use Countly, even if they are not
currently using push notification functionality either within
the app or via Countly.

I'm not exactly an Objective C developer, so please check what I've done here is sane - basically adding another preprocessor flag to disable all code related to the push notifications feature via `COUNTLY_EXCLUDE_USERNOTIFICATIONS` similar to the existing `COUNTLY_EXCLUDE_IDFA`.