### PR TITLE
Added config flag "ignoreTrustExceptions"

### DIFF
--- a/Countly.m
+++ b/Countly.m
@@ -71,6 +71,7 @@ long long appLoadStartTime;
 
     CountlyCommon.sharedInstance.hasStarted = YES;
     CountlyCommon.sharedInstance.enableDebug = config.enableDebug;
+	CountlyCommon.sharedInstance.ignoreTrustExceptions = config.ignoreTrustExceptions;
     CountlyCommon.sharedInstance.loggerDelegate = config.loggerDelegate;
     CountlyConsentManager.sharedInstance.requiresConsent = config.requiresConsent;
 

--- a/Countly.m
+++ b/Countly.m
@@ -71,7 +71,7 @@ long long appLoadStartTime;
 
     CountlyCommon.sharedInstance.hasStarted = YES;
     CountlyCommon.sharedInstance.enableDebug = config.enableDebug;
-	CountlyCommon.sharedInstance.ignoreTrustExceptions = config.ignoreTrustExceptions;
+    CountlyCommon.sharedInstance.shouldIgnoreTrustCheck = config.shouldIgnoreTrustCheck;
     CountlyCommon.sharedInstance.loggerDelegate = config.loggerDelegate;
     CountlyConsentManager.sharedInstance.requiresConsent = config.requiresConsent;
 

--- a/CountlyCommon.h
+++ b/CountlyCommon.h
@@ -58,7 +58,7 @@ NS_ERROR_ENUM(kCountlyErrorDomain)
 
 @property (nonatomic) BOOL hasStarted;
 @property (nonatomic) BOOL enableDebug;
-@property (nonatomic) BOOL ignoreTrustExceptions;
+@property (nonatomic) BOOL shouldIgnoreTrustCheck;
 @property (nonatomic, weak) id <CountlyLoggerDelegate> loggerDelegate;
 @property (nonatomic) BOOL enableAppleWatch;
 @property (nonatomic, copy) NSString* attributionID;

--- a/CountlyCommon.h
+++ b/CountlyCommon.h
@@ -58,6 +58,7 @@ NS_ERROR_ENUM(kCountlyErrorDomain)
 
 @property (nonatomic) BOOL hasStarted;
 @property (nonatomic) BOOL enableDebug;
+@property (nonatomic) BOOL ignoreTrustExceptions;
 @property (nonatomic, weak) id <CountlyLoggerDelegate> loggerDelegate;
 @property (nonatomic) BOOL enableAppleWatch;
 @property (nonatomic, copy) NSString* attributionID;

--- a/CountlyConfig.h
+++ b/CountlyConfig.h
@@ -130,7 +130,7 @@ extern CLYMetricKey const CLYMetricKeyInstalledWatchApp;
  * For ignoring all SSL trust exceptions
  * @discussion If set, all SSL trust exceptions will be ignoring. Works only in DEBUG mode
  */
-@property (nonatomic) BOOL ignoreTrustExceptions;
+@property (nonatomic) BOOL shouldIgnoreTrustCheck;
 
 /**
  * For receiving SDK's internal logs even in production builds.

--- a/CountlyConfig.h
+++ b/CountlyConfig.h
@@ -127,6 +127,12 @@ extern CLYMetricKey const CLYMetricKeyInstalledWatchApp;
 @property (nonatomic) BOOL enableDebug;
 
 /**
+ * For ignoring all SSL trust exceptions
+ * @discussion If set, all SSL trust exceptions will be ignoring. Works only in DEBUG mode
+ */
+@property (nonatomic) BOOL ignoreTrustExceptions;
+
+/**
  * For receiving SDK's internal logs even in production builds.
  * @discussion If set, SDK will forward its internal logs to this delegate object regardless of @c enableDebug initial config value.
  * @discussion @c internalLog: method declared as @c required in @c CountlyLoggerDelegate protocol will be called with log @c NSString.

--- a/CountlyConnectionManager.m
+++ b/CountlyConnectionManager.m
@@ -653,8 +653,14 @@ const NSInteger kCountlyGETRequestMaxLength = 2048;
 
         if (localKey) CFRelease(localKey);
     }
-
-    SecTrustResultType serverTrustResult;
+	
+#if DEBUG
+	if (CountlyCommon.sharedInstance.ignoreTrustExceptions) {
+		SecTrustSetExceptions(serverTrust, SecTrustCopyExceptions(serverTrust));
+	}
+#endif
+	
+	SecTrustResultType serverTrustResult;
     SecTrustEvaluate(serverTrust, &serverTrustResult);
     BOOL isServerCertValid = (serverTrustResult == kSecTrustResultUnspecified || serverTrustResult == kSecTrustResultProceed);
 

--- a/CountlyConnectionManager.m
+++ b/CountlyConnectionManager.m
@@ -653,14 +653,14 @@ const NSInteger kCountlyGETRequestMaxLength = 2048;
 
         if (localKey) CFRelease(localKey);
     }
-	
-#if DEBUG
-	if (CountlyCommon.sharedInstance.ignoreTrustExceptions) {
-		SecTrustSetExceptions(serverTrust, SecTrustCopyExceptions(serverTrust));
-	}
-#endif
-	
-	SecTrustResultType serverTrustResult;
+    
+    #if DEBUG
+    if (CountlyCommon.sharedInstance.shouldIgnoreTrustCheck) {
+        SecTrustSetExceptions(serverTrust, SecTrustCopyExceptions(serverTrust));
+    }
+    #endif
+    
+    SecTrustResultType serverTrustResult;
     SecTrustEvaluate(serverTrust, &serverTrustResult);
     BOOL isServerCertValid = (serverTrustResult == kSecTrustResultUnspecified || serverTrustResult == kSecTrustResultProceed);
 


### PR DESCRIPTION
This flag helps for developers to debug Countly with self-signed SSL certificate. Works only in Debug mode.