### PR TITLE
Mark API unavailable to extensions.

### DIFF
--- a/Countly.h
+++ b/Countly.h
@@ -317,7 +317,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Shows default system dialog that asks for user's permission to display notifications.
  * @discussion A unified convenience method that handles asking for notification permission on both iOS10 and older iOS versions with badge, sound and alert notification types.
  */
-- (void)askForNotificationPermission;
+- (void)askForNotificationPermission NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
 
 /**
  * Shows default system dialog that asks for user's permission to display notifications with given options and completion handler.
@@ -327,7 +327,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param options Bitwise combination of notification types (badge, sound or alert) the app wants to display
  * @param completionHandler A completion handler block to be executed when user answers notification permission dialog
  */
-- (void)askForNotificationPermissionWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError * __nullable error))completionHandler API_AVAILABLE(ios(10.0), macos(10.14));
+- (void)askForNotificationPermissionWithOptions:(UNAuthorizationOptions)options completionHandler:(void (^)(BOOL granted, NSError * __nullable error))completionHandler API_AVAILABLE(ios(10.0), macos(10.14)) NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
 
 /**
  * Records action event for a manually presented push notification with custom action buttons.
@@ -337,7 +337,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param userInfo Manually presented push notification dictionary
  * @param buttonIndex Index of custom action button user clicked
  */
-- (void)recordActionForNotification:(NSDictionary *)userInfo clickedButtonIndex:(NSInteger)buttonIndex;
+- (void)recordActionForNotification:(NSDictionary *)userInfo clickedButtonIndex:(NSInteger)buttonIndex NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
 
 /**
  * Records push notification token to Countly Server for current device ID.
@@ -345,13 +345,13 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion For cases like a new user logs in and device ID changes, or a new app key is set.
  * @discussion In general, push notification token is handled automatically and this method does not need to be called manually.
  */
-- (void)recordPushNotificationToken;
+- (void)recordPushNotificationToken NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
 
 /**
  * Clears push notification token on Countly Server for current device ID.
  * @discussion Can be used to clear push notification token for current device ID, before the current user logs out and device ID changes, without waiting for the app to be restarted.
  */
-- (void)clearPushNotificationToken;
+- (void)clearPushNotificationToken NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
 #endif
 #endif
 
@@ -550,7 +550,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion If user dismissed dialog without giving a rating, this value will be 0 and it will not be sent to Countly Server.
  * @param completion A block object to be executed when user gives a star-rating or dismisses dialog without rating
  */
-- (void)askForStarRating:(void(^)(NSInteger rating))completion;
+- (void)askForStarRating:(void(^)(NSInteger rating))completion NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
 
 /**
  * Presents feedback widget with given ID in a WKWebView placed in a UIViewController.

--- a/Countly.m
+++ b/Countly.m
@@ -133,14 +133,14 @@ long long appLoadStartTime;
 
 #if (TARGET_OS_IOS || TARGET_OS_OSX)
 #ifndef COUNTLY_EXCLUDE_PUSHNOTIFICATIONS
-    if ([config.features containsObject:CLYPushNotifications])
+    if ([config.features containsObject:CLYPushNotifications] && ![[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"])
     {
         CountlyPushNotifications.sharedInstance.isEnabledOnInitialConfig = YES;
         CountlyPushNotifications.sharedInstance.pushTestMode = config.pushTestMode;
         CountlyPushNotifications.sharedInstance.sendPushTokenAlways = config.sendPushTokenAlways;
         CountlyPushNotifications.sharedInstance.doNotShowAlertForNotifications = config.doNotShowAlertForNotifications;
         CountlyPushNotifications.sharedInstance.launchNotification = config.launchNotification;
-        [CountlyPushNotifications.sharedInstance startPushNotifications];
+        [CountlyPushNotifications.sharedInstance performSelector:@selector(startPushNotifications)];
     }
 #endif
 #endif

--- a/CountlyCommon.h
+++ b/CountlyCommon.h
@@ -78,12 +78,12 @@ void CountlyPrint(NSString *stringToPrint);
 - (NSInteger)timeSinceLaunch;
 - (NSTimeInterval)uniqueTimestamp;
 
-- (void)startBackgroundTask;
-- (void)finishBackgroundTask;
+- (void)startBackgroundTask NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
+- (void)finishBackgroundTask NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
 
 #if (TARGET_OS_IOS || TARGET_OS_TV)
-- (UIViewController *)topViewController;
-- (void)tryPresentingViewController:(UIViewController *)viewController;
+- (UIViewController *)topViewController NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
+- (void)tryPresentingViewController:(UIViewController *)viewController NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
 #endif
 
 - (void)startAppleWatchMatching;

--- a/CountlyCommon.m
+++ b/CountlyCommon.m
@@ -216,13 +216,15 @@ void CountlyPrint(NSString *stringToPrint)
 {
 #if (TARGET_OS_IOS)
     UIInterfaceOrientation interfaceOrientation = UIInterfaceOrientationUnknown;
-    if (@available(iOS 13.0, *))
-    {
-        interfaceOrientation = UIApplication.sharedApplication.keyWindow.windowScene.interfaceOrientation;
-    }
-    else
-    {
-        interfaceOrientation = UIApplication.sharedApplication.statusBarOrientation;
+    if (![[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"]) {
+        if (@available(iOS 13.0, *))
+        {
+            interfaceOrientation = ((UIApplication *)[UIApplication performSelector:@selector(sharedApplication)]).keyWindow.windowScene.interfaceOrientation;
+        }
+        else
+        {
+            interfaceOrientation = ((UIApplication *)[UIApplication performSelector:@selector(sharedApplication)]).statusBarOrientation;
+        }
     }
 
     NSString* mode = nil;
@@ -377,11 +379,11 @@ const CGFloat kCountlyDismissButtonStandardStatusBarHeight = 20.0;
     rect.origin.x = self.superview.bounds.size.width - self.bounds.size.width - kCountlyDismissButtonMargin;
     rect.origin.y = kCountlyDismissButtonMargin;
 
-    if (shouldConsiderStatusBar)
+    if (shouldConsiderStatusBar && ![[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"])
     {
         if (@available(iOS 11.0, *))
         {
-            CGFloat top = UIApplication.sharedApplication.keyWindow.safeAreaInsets.top;
+            CGFloat top = ((UIApplication *)[UIApplication performSelector:@selector(sharedApplication)]).keyWindow.safeAreaInsets.top;
             if (top)
             {
                 rect.origin.y += top;

--- a/CountlyConnectionManager.m
+++ b/CountlyConnectionManager.m
@@ -135,7 +135,9 @@ const NSInteger kCountlyGETRequestMaxLength = 2048;
         return;
     }
 
-    [CountlyCommon.sharedInstance startBackgroundTask];
+    if (![[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"]) {
+        [CountlyCommon.sharedInstance performSelector:@selector(startBackgroundTask)];
+    }
 
     NSString* queryString = firstItemInQueue;
 

--- a/CountlyConsentManager.m
+++ b/CountlyConsentManager.m
@@ -323,14 +323,18 @@ CLYConsent const CLYConsentRemoteConfig         = @"remote-config";
         CLY_LOG_D(@"Consent for PushNotifications is given.");
 
 #ifndef COUNTLY_EXCLUDE_PUSHNOTIFICATIONS
-        [CountlyPushNotifications.sharedInstance startPushNotifications];
+        if (![[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"]) {
+            [CountlyPushNotifications.sharedInstance performSelector:@selector(startPushNotifications)];
+        }
 #endif
     }
     else
     {
         CLY_LOG_D(@"Consent for PushNotifications is cancelled.");
 #ifndef COUNTLY_EXCLUDE_PUSHNOTIFICATIONS
-        [CountlyPushNotifications.sharedInstance stopPushNotifications];
+        if (![[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"]) {
+            [CountlyPushNotifications.sharedInstance performSelector:@selector(stopPushNotifications)];
+        }
 #endif
     }
 #endif

--- a/CountlyDeviceInfo.m
+++ b/CountlyDeviceInfo.m
@@ -64,7 +64,9 @@ CLYMetricKey const CLYMetricKeyInstalledWatchApp  = @"_installed_watch_app";
 #endif
 
 #if (TARGET_OS_IOS || TARGET_OS_TV)
-        self.isInBackground = (UIApplication.sharedApplication.applicationState == UIApplicationStateBackground);
+        if (![[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"]) {
+            self.isInBackground = (((UIApplication *)[UIApplication performSelector:@selector(sharedApplication)]).applicationState == UIApplicationStateBackground);
+        }
 
         [NSNotificationCenter.defaultCenter addObserver:self
                                                selector:@selector(applicationDidEnterBackground:)

--- a/CountlyFeedbackWidget.h
+++ b/CountlyFeedbackWidget.h
@@ -26,7 +26,7 @@ extern CLYFeedbackWidgetType const CLYFeedbackWidgetTypeNPS;
  * @discussion Calls to this method will be ignored if consent for @c CLYConsentFeedback is not given
  * while @c requiresConsent flag is set on initial configuration.
  */
-- (void)present;
+- (void)present NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
 
 #endif
 @end

--- a/CountlyFeedbacks.h
+++ b/CountlyFeedbacks.h
@@ -17,7 +17,7 @@ extern NSString* const kCountlyFBKeyID;
 #if (TARGET_OS_IOS)
 + (instancetype)sharedInstance;
 
-- (void)showDialog:(void(^)(NSInteger rating))completion;
+- (void)showDialog:(void(^)(NSInteger rating))completion NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
 - (void)checkFeedbackWidgetWithID:(NSString *)widgetID completionHandler:(void (^)(NSError * error))completionHandler;
 - (void)checkForStarRatingAutoAsk;
 

--- a/CountlyFeedbacks.m
+++ b/CountlyFeedbacks.m
@@ -287,7 +287,7 @@ const CGFloat kCountlyStarRatingButtonSize = 40.0;
     [task resume];
 }
 
-- (void)presentFeedbackWidgetWithID:(NSString *)widgetID completionHandler:(void (^)(NSError * error))completionHandler
+- (void)presentFeedbackWidgetWithID:(NSString *)widgetID completionHandler:(void (^)(NSError * error))completionHandler NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
     __block CLYInternalViewController* webVC = CLYInternalViewController.new;
     webVC.view.backgroundColor = UIColor.whiteColor;

--- a/CountlyPersistency.m
+++ b/CountlyPersistency.m
@@ -384,7 +384,9 @@ NSString* const kCountlyCustomCrashLogFileName = @"CountlyCustomCrash.log";
 
 #pragma clang diagnostic pop
 
-    [CountlyCommon.sharedInstance finishBackgroundTask];
+    if (![[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"]) {
+        [CountlyCommon.sharedInstance performSelector:@selector(finishBackgroundTask)];
+    }
 }
 
 #pragma mark ---

--- a/CountlyPushNotifications.h
+++ b/CountlyPushNotifications.h
@@ -17,12 +17,12 @@
 + (instancetype)sharedInstance;
 
 #if (TARGET_OS_IOS || TARGET_OS_OSX)
-- (void)startPushNotifications;
-- (void)stopPushNotifications;
-- (void)askForNotificationPermissionWithOptions:(NSUInteger)options completionHandler:(void (^)(BOOL granted, NSError * error))completionHandler;
-- (void)recordActionForNotification:(NSDictionary *)userInfo clickedButtonIndex:(NSInteger)buttonIndex;
-- (void)sendToken;
-- (void)clearToken;
+- (void)startPushNotifications NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
+- (void)stopPushNotifications NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
+- (void)askForNotificationPermissionWithOptions:(NSUInteger)options completionHandler:(void (^)(BOOL granted, NSError * error))completionHandler NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
+- (void)recordActionForNotification:(NSDictionary *)userInfo clickedButtonIndex:(NSInteger)buttonIndex NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
+- (void)sendToken NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
+- (void)clearToken NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.");
 #endif
 #endif
 @end

--- a/CountlyPushNotifications.m
+++ b/CountlyPushNotifications.m
@@ -100,7 +100,7 @@ CLYPushTestMode const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFl
     [CLYApplication.sharedApplication unregisterForRemoteNotifications];
 }
 
-- (void)swizzlePushNotificationMethods
+- (void)swizzlePushNotificationMethods NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
     static BOOL alreadySwizzled;
     if (alreadySwizzled)
@@ -240,7 +240,7 @@ CLYPushTestMode const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFl
     [CountlyConnectionManager.sharedInstance sendPushToken:@""];
 }
 
-- (void)handleNotification:(NSDictionary *)notification
+- (void)handleNotification:(NSDictionary *)notification NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
 #if (TARGET_OS_IOS || TARGET_OS_OSX)
     if (!CountlyConsentManager.sharedInstance.consentForPushNotifications)
@@ -367,7 +367,7 @@ CLYPushTestMode const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFl
 #endif
 }
 
-- (void)openURL:(NSString *)URLString
+- (void)openURL:(NSString *)URLString NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
     if (!URLString)
         return;
@@ -409,7 +409,7 @@ CLYPushTestMode const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFl
 
 #pragma mark ---
 
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler API_AVAILABLE(ios(10.0), macos(10.14))
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler API_AVAILABLE(ios(10.0), macos(10.14)) NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
     CLY_LOG_D(@"userNotificationCenter:willPresentNotification:withCompletionHandler:");
     CLY_LOG_D(@"%@", notification.request.content.userInfo.description);
@@ -431,7 +431,7 @@ CLYPushTestMode const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFl
         completionHandler(UNNotificationPresentationOptionNone);
 }
 
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler API_AVAILABLE(ios(10.0), macos(10.14))
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler API_AVAILABLE(ios(10.0), macos(10.14)) NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
     CLY_LOG_D(@"userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:");
     CLY_LOG_D(@"%@", response.notification.request.content.userInfo.description);
@@ -472,7 +472,7 @@ CLYPushTestMode const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFl
         completionHandler();
 }
 
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center openSettingsForNotification:(UNNotification *)notification API_AVAILABLE(ios(12.0), macos(10.14))
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center openSettingsForNotification:(UNNotification *)notification API_AVAILABLE(ios(12.0), macos(10.14)) NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
     if (@available(iOS 12.0, macOS 10.14, *))
     {
@@ -502,7 +502,7 @@ CLYPushTestMode const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFl
 
 @implementation NSObject (CountlyPushNotifications)
 #if (TARGET_OS_IOS || TARGET_OS_OSX)
-- (void)Countly_application:(CLYApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
+- (void)Countly_application:(CLYApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
     CLY_LOG_D(@"App didRegisterForRemoteNotificationsWithDeviceToken: %@", deviceToken);
 
@@ -518,7 +518,7 @@ CLYPushTestMode const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFl
     [self Countly_application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
-- (void)Countly_application:(CLYApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
+- (void)Countly_application:(CLYApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
     CLY_LOG_D(@"App didFailToRegisterForRemoteNotificationsWithError: %@", error);
 
@@ -531,7 +531,7 @@ CLYPushTestMode const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFl
 #endif
 
 #if (TARGET_OS_IOS)
-- (void)Countly_application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+- (void)Countly_application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
     CLY_LOG_D(@"App didRegisterUserNotificationSettings: %@", notificationSettings);
 
@@ -545,7 +545,7 @@ CLYPushTestMode const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFl
     [self Countly_application:application didRegisterUserNotificationSettings:notificationSettings];
 }
 
-- (void)Countly_application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
+- (void)Countly_application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
     CLY_LOG_D(@"App didReceiveRemoteNotification:fetchCompletionHandler");
 
@@ -555,7 +555,7 @@ CLYPushTestMode const CLYPushTestModeTestFlightOrAdHoc = @"CLYPushTestModeTestFl
 }
 
 #elif (TARGET_OS_OSX)
-- (void)Countly_application:(NSApplication *)application didReceiveRemoteNotification:(NSDictionary<NSString *,id> *)userInfo
+- (void)Countly_application:(NSApplication *)application didReceiveRemoteNotification:(NSDictionary<NSString *,id> *)userInfo NS_EXTENSION_UNAVAILABLE_IOS("Only available from application containers.")
 {
     CLY_LOG_D(@"App didReceiveRemoteNotification:");
 

--- a/CountlyViewTracking.m
+++ b/CountlyViewTracking.m
@@ -182,9 +182,11 @@ NSString* const kCountlyVTKeyDur      = @"dur";
 
     [self swizzleViewTrackingMethods];
 
-    UIViewController* topVC = CountlyCommon.sharedInstance.topViewController;
-    NSString* viewTitle = [CountlyViewTracking.sharedInstance titleForViewController:topVC];
-    [self startView:viewTitle];
+    if (![[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"]) {
+        UIViewController* topVC = [CountlyCommon.sharedInstance performSelector:@selector(topViewController)];
+        NSString* viewTitle = [CountlyViewTracking.sharedInstance titleForViewController:topVC];
+        [self startView:viewTitle];
+    }
 }
 
 - (void)swizzleViewTrackingMethods


### PR DESCRIPTION
Related to #179 #150

This change (or a similar one) is required in order to build the Countly SDK on Xcode 13 (since beta 3). Countly is currently dead in the water for Xcode 13/iOS 15.

This solution uses a runtime bundle extension check to turn off extension-unavailable APIs invoked from Countly APIs which are considered to be shared between application and extension targets. To avoid compiler analysis errors which do not recognize this guard, I've had to resort to hiding API usage behind `performSelector:`.

This is necessary to prevent the unavailable annotations from spreading to encompass the entire Countly API.

The final solution could probably tidy up the runtime checks a bit and should give consideration to traditional application/extension concerns such as whether there's a need for data sharing and synchronization.