### PR TITLE
Fix the minimum supported iOS platform version.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
 
     platforms: 
     [
-        .iOS(.v8),
+        .iOS(.v9),
         .macOS(.v10_10),
         .tvOS(.v9),
         .watchOS(.v2)


### PR DESCRIPTION
Resolves the following Xcode warning:
The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 15.0.99.