### PR TITLE
Exclude SECURITY.md from SPM.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,8 @@ let package = Package(
                 "LICENSE.md",
                 "README.md",
                 "countly_dsym_uploader.sh",
-                "CHANGELOG.md"
+                "CHANGELOG.md",
+                "SECURITY.md"
             ],
 
             linkerSettings: 


### PR DESCRIPTION
Resolves:
found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    SourcePackages/checkouts/countly-sdk-ios/SECURITY.md