### PR TITLE
Allow usage of suspension mechanism for broader use.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Updated suspend/resume mechanism for general availability & to temporarily shut down event recording.
+
 ## 20.11.3
 - Added optional appear and dismiss callbacks for feedback widget presenting
 - Added manually displayed and recorded feedback widgets support

--- a/Countly.h
+++ b/Countly.h
@@ -91,19 +91,28 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)endSession;
 
-#if (TARGET_OS_WATCH)
 /**
- * Suspends Countly, adds recorded events to request queue and ends current session.
- * @discussion This method needs to be called manually only on @c watchOS, on other platforms it will be called automatically.
+ * Suspends Countly, adding recorded events to request queue, pausing view tracking and ending the current session.
+ * @discussion
+ * On @c watchOS, call this in your extension delegate's -applicationWillResignActive.
+ * It may also be used to temporarily suspend Countly for other reasons, such as while a user enters an incognito session.
  */
 - (void)suspend;
 
 /**
- * Resumes Countly, begins a new session after the app comes to foreground.
- * @discussion This method needs to be called manually only on @c watchOS, on other platforms it will be called automatically.
+ * Resumes Countly, beginning a new session and resuming view tracking.
+ * @discussion
+ * On @c watchOS, call this in your extension delegate's -applicationDidBecomeActive.
+ * It may also be used to resume Countly for other reasons, such as when a user exits an incognito session.
  */
 - (void)resume;
-#endif
+
+/**
+ * Determine whether Countly is currently tracking events.
+ * @discussion
+ * Countly is tracking events after it has been started and while it hasn't been suspended.
+ */
+- (BOOL)isRunning;
 
 
 

--- a/Countly.m
+++ b/Countly.m
@@ -273,9 +273,7 @@ long long appLoadStartTime;
 
 - (void)suspend
 {
-#if (TARGET_OS_WATCH)
     CLY_LOG_I(@"%s", __FUNCTION__);
-#endif
 
     if (!CountlyCommon.sharedInstance.hasStarted)
         return;
@@ -299,9 +297,7 @@ long long appLoadStartTime;
 
 - (void)resume
 {
-#if (TARGET_OS_WATCH)
     CLY_LOG_I(@"%s", __FUNCTION__);
-#endif
 
     if (!CountlyCommon.sharedInstance.hasStarted)
         return;
@@ -323,6 +319,11 @@ long long appLoadStartTime;
     [CountlyViewTracking.sharedInstance resumeView];
 
     isSuspended = NO;
+}
+
+- (BOOL)isRunning
+{
+    return CountlyCommon.sharedInstance.hasStarted && !isSuspended;
 }
 
 #pragma mark ---
@@ -559,7 +560,7 @@ long long appLoadStartTime;
 {
     CLY_LOG_I(@"%s %@ %@ %lu %f %f", __FUNCTION__, key, segmentation, (unsigned long)count, sum, duration);
 
-    if (!CountlyConsentManager.sharedInstance.consentForEvents)
+    if (isSuspended || !CountlyConsentManager.sharedInstance.consentForEvents)
         return;
 
     [self recordEvent:key segmentation:segmentation count:count sum:sum duration:duration timestamp:CountlyCommon.sharedInstance.uniqueTimestamp];
@@ -603,7 +604,7 @@ long long appLoadStartTime;
 {
     CLY_LOG_I(@"%s %@", __FUNCTION__, key);
 
-    if (!CountlyConsentManager.sharedInstance.consentForEvents)
+    if (isSuspended || !CountlyConsentManager.sharedInstance.consentForEvents)
         return;
 
     CountlyEvent *event = CountlyEvent.new;
@@ -624,7 +625,7 @@ long long appLoadStartTime;
 {
     CLY_LOG_I(@"%s %@ %@ %lu %f", __FUNCTION__, key, segmentation, (unsigned long)count, sum);
 
-    if (!CountlyConsentManager.sharedInstance.consentForEvents)
+    if (isSuspended || !CountlyConsentManager.sharedInstance.consentForEvents)
         return;
 
     CountlyEvent *event = [CountlyPersistency.sharedInstance timedEventForKey:key];
@@ -647,7 +648,7 @@ long long appLoadStartTime;
 {
     CLY_LOG_I(@"%s %@", __FUNCTION__, key);
 
-    if (!CountlyConsentManager.sharedInstance.consentForEvents)
+    if (isSuspended || !CountlyConsentManager.sharedInstance.consentForEvents)
         return;
 
     CountlyEvent *event = [CountlyPersistency.sharedInstance timedEventForKey:key];


### PR DESCRIPTION
It is useful to allow an application to request temporary manual suspension of event recording.

Currently, the only available mechanism to shut down Countly's tracking
once started is the consent mechanism. This mechanism is too
heavy-handed for temporary/situational suspension since it affects
global consent counters for the userbase.

The existing suspension mechanism is a great fit for temporarily
shutting down Countly and allowing Countly to resume later on.

Suggested use case:
- A user enters incognito mode and the application needs to be able to make privacy guarantees.
- The app wants to go offline and ensure that it is not emitting or triggering any network activity.

Note:
- This PR also ensures that while Countly is suspended, any manual event recording activity is ignored. This shouldn't conflict with the prior use of the suspend/resume mechanism (and in fact, these events really shouldn't be processed while there is no active session).