### PR TITLE
Ability to programmatically submit a feedback widget.

### DIFF
--- a/Countly.h
+++ b/Countly.h
@@ -557,6 +557,25 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)presentFeedbackWidgetWithID:(NSString *)widgetID completionHandler:(void (^)(NSError * __nullable error))completionHandler;
 
 /**
+ * Manually submits feedback for a widget with given ID.
+ * @discussion If the feedback widget with given ID is available, feedback will be submitted.
+ * @discussion Otherwise, @c completionHandler will be executed with an @c NSError.
+ * @discussion @c completionHandler will also be executed with @c nil once feedback has been successfully submitted.
+ * @discussion Calls to this method will be ignored and @c completionHandler will not be executed if:
+ * @discussion - Consent for @c CLYConsentFeedback is not given, while @c requiresConsent flag is set on initial configuration.
+ * @discussion - Current device ID is @c CLYTemporaryDeviceID.
+ * @discussion - @c widgetID is not a non-zero length valid string.
+ * @param widgetID ID of the feedback widget created on Countly Server.
+ * @param rating A user rating, ranging from 1 - 5.
+ * @param comment An optional user message to include with the rating.
+ * @param email An optional e-mail address if the user wants to be contacted.
+ * @param completionHandler A completion handler block to be executed when feedback has been submitted.
+ */
+- (void)submitFeedbackWidgetWithID:(NSString *)widgetID rating:(NSUInteger)rating
+                           comment:(NSString * __nullable)comment email:(NSString * __nullable)email
+                 completionHandler:(void (^)(NSError * __nullable error))completionHandler;
+
+/**
  * Fetches a list of available feedback widgets.
  * @discussion When feedback widgets are fetched successfully, @c completionHandler will be executed with an array of @c CountlyFeedbackWidget objects.
  * @discussion Otherwise, @c completionHandler will be executed with an @c NSError.

--- a/Countly.m
+++ b/Countly.m
@@ -928,6 +928,14 @@ long long appLoadStartTime;
     [CountlyFeedbacks.sharedInstance checkFeedbackWidgetWithID:widgetID completionHandler:completionHandler];
 }
 
+- (void)submitFeedbackWidgetWithID:(NSString *)widgetID rating:(NSUInteger)rating comment:(NSString *)comment email:(NSString *)email completionHandler:(void (^)(NSError * error))completionHandler
+{
+    CLY_LOG_I(@"%s %@", __FUNCTION__, widgetID);
+
+    [CountlyFeedbacks.sharedInstance submitFeedbackWidgetWithID:widgetID rating:rating comment:comment email:email
+                                              completionHandler:completionHandler];
+}
+
 - (void)getFeedbackWidgets:(void (^)(NSArray <CountlyFeedbackWidget *> *feedbackWidgets, NSError * error))completionHandler
 {
     CLY_LOG_I(@"%s %@", __FUNCTION__, completionHandler);

--- a/CountlyFeedbacks.h
+++ b/CountlyFeedbacks.h
@@ -21,6 +21,8 @@ extern NSString* const kCountlyReservedEventStarRating;
 
 - (void)showDialog:(void(^)(NSInteger rating))completion;
 - (void)checkFeedbackWidgetWithID:(NSString *)widgetID completionHandler:(void (^)(NSError * error))completionHandler;
+- (void)submitFeedbackWidgetWithID:(NSString *)widgetID rating:(NSUInteger)rating comment:(NSString *)comment email:(NSString *)email
+                 completionHandler:(void (^)(NSError * error))completionHandler;
 - (void)checkForStarRatingAutoAsk;
 
 - (void)getFeedbackWidgets:(void (^)(NSArray <CountlyFeedbackWidget *> *feedbackWidgets, NSError *error))completionHandler;

--- a/CountlyFeedbacks.m
+++ b/CountlyFeedbacks.m
@@ -339,8 +339,8 @@ const CGFloat kCountlyStarRatingButtonSize = 40.0;
             @"app_version": CountlyDeviceInfo.appVersion,
             @"platform_version_rate": @"",
             @"rating": @(rating),
-            @"email": email,
-            @"comment": comment
+            @"email": (id)email?: [NSNull null],
+            @"comment": (id)comment?: [NSNull null]
     };
     event.timestamp = CountlyCommon.sharedInstance.uniqueTimestamp;
     event.hourOfDay = CountlyCommon.sharedInstance.hourOfDay;


### PR DESCRIPTION
Feedback widgets are very useful for gauging the progression of the userbase's mood as the application evolves.

Regrettably, Countly currently only offers a locked-in flow for feedback widgets through a custom web view. This is not a great experience in most modern apps which prefer to keep the user both in their current flow and not interrupt their desired current activity, as well as keeping them in the app's design. Respect for branding is also an important factor.

For all of these reasons, it is important that developers have the flexibility to implement feedback in their own way, and Countly should supply an API for them to submit feedback garnered in whatever way developers deem best fitting with the product requirements and UX.

This PR exposes the following API:
```
- (void)submitFeedbackWidgetWithID:(NSString *)widgetID rating:(NSUInteger)rating
                           comment:(NSString * __nullable)comment email:(NSString * __nullable)email
                 completionHandler:(void (^)(NSError * __nullable error))completionHandler;
```

It tries to adopt the existing paradigms as much as possible. However, it is clear that there is plenty of room in the entire feedback functionality:
- The shared `NSURLSession` is used, rather than Countly's own, which might have been configured differently by the user (`URLSessionConfiguration`), thus disrespecting this user preference.
- Submission is only supported via `GET` requests. The endpoint does not support `POST`, thus disrespecting `alwaysUsePOST`.
- Submitted queries do not include the checksum, thereby failing to perform the extra `secretSalt` security validation.
- Submission is happening through a separate endpoint (`/i/feedback` rather than `/i`). This is counter to how other reserved events are submitted, such as the regular star rating. It also means we cannot use the traditional queue.
- It might also make sense to expose star rating to programmatic submission, similar to this one.