### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,7 @@ let package = Package(
             [
                 "Info.plist",
                 "Countly.podspec",
+                "Countly-PL.podspec",
                 "LICENSE.md",
                 "README.md",
                 "countly_dsym_uploader.sh",


### PR DESCRIPTION
Add "Countly-PL.podspec" to exclude list in Package.swift in order to avoid a warning when including this as a Swift Package in Xcode 13 (Beta 2).