### PR TITLE
Added macOS as supported platform

### DIFF
--- a/Countly.xcodeproj/project.pbxproj
+++ b/Countly.xcodeproj/project.pbxproj
@@ -404,17 +404,19 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MARKETING_VERSION = 21.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ly.count.CountlyiOSSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -432,17 +434,19 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MARKETING_VERSION = 21.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ly.count.CountlyiOSSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
Running `carthage update --use-xcframeworks` with the Cartfile `github "Countly/countly-sdk-ios"` created only a frameworks for iOS, because in "Build Settings" - "Architectures" - "Supported Plattforms" only iOS was set (seemingly the default value).

Adding explicitly `macosx` here also adds a macOS framework for Intel and Apple Silicon to the output.

Carthage now creates a `Countly.xcframework` containing `ios-arm64_armv7`, `ios-arm64_i386_x86_64-simulator` **and** also `macos-arm64_x86_64`.

Unfortunately the SDKROOT must be changed to "macosx", because otherwise the building with Carthage fails for some reason.

I verified that the resulting XCFramework can be used on native macOS apps (not only Catalyst), real iOS devices and iOS simulator. These are the targets for my app.