### PR TITLE
Added back battery level reporting to crash reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## xx.xx.xx
+- Added back battery level reporting to crash reporting. Battery level is only reported if battery was enabled before.
+
 ## 23.02.2
 - Added server configuration functionality. This is an experimental feature.
 - Not reporting battery level in the crash handler to prevent hanging

--- a/CountlyCrashReporter.m
+++ b/CountlyCrashReporter.m
@@ -273,7 +273,12 @@ void CountlyExceptionHandler(NSException *exception, bool isFatal, bool isAutoDe
     crashReport[kCountlyCRKeyRAMTotal] = @(CountlyDeviceInfo.totalRAM / kCLYMebibit);
     crashReport[kCountlyCRKeyDiskCurrent] = @((CountlyDeviceInfo.totalDisk - CountlyDeviceInfo.freeDisk) / kCLYMebibit);
     crashReport[kCountlyCRKeyDiskTotal] = @(CountlyDeviceInfo.totalDisk / kCLYMebibit);
-    //crashReport[kCountlyCRKeyBattery] = @(CountlyDeviceInfo.batteryLevel);//not reporting this to prevent hanging in the middle of crash reporting
+    NSInteger batteryLevel = CountlyDeviceInfo.batteryLevel;
+    // We will add battery level only if there is a valid value.
+    if(batteryLevel >= 0)
+    {
+        crashReport[kCountlyCRKeyBattery] = @(batteryLevel);
+    }
     crashReport[kCountlyCRKeyOrientation] = CountlyDeviceInfo.orientation;
     crashReport[kCountlyCRKeyOnline] = @((CountlyDeviceInfo.connectionType) ? 1 : 0 );
     crashReport[kCountlyCRKeyRoot] = @(CountlyDeviceInfo.isJailbroken);

--- a/CountlyDeviceInfo.m
+++ b/CountlyDeviceInfo.m
@@ -396,10 +396,16 @@ CLYMetricKey const CLYMetricKeyInstalledWatchApp  = @"_installed_watch_app";
     return [homeDirectory[NSFileSystemSize] longLongValue];
 }
 
+// If it is not possible to retrieve a valid value then it will return a -1.
 + (NSInteger)batteryLevel
 {
 #if (TARGET_OS_IOS)
-    UIDevice.currentDevice.batteryMonitoringEnabled = YES;
+    // If battey state is "unknown" that means that battery monitoring is not enabled.
+    // In that case we will not able to retrieve a battery level.
+    if(UIDevice.currentDevice.batteryState == UIDeviceBatteryStateUnknown)
+    {
+        return -1;
+    }
     return abs((int)(UIDevice.currentDevice.batteryLevel * 100));
 #elif (TARGET_OS_WATCH)
     return abs((int)(WKInterfaceDevice.currentDevice.batteryLevel * 100));
@@ -415,7 +421,7 @@ CLYMetricKey const CLYMetricKeyInstalledWatchApp  = @"_installed_watch_app";
     return (currentLevel / (float)maxLevel) * 100;
 #endif
 
-    return 100;
+    return -1;
 }
 
 + (NSString *)orientation


### PR DESCRIPTION
Battery level is only reported if battery was enabled before.